### PR TITLE
Fix sidebar_recent typo

### DIFF
--- a/app/assets/javascripts/components/sidebar/sidebar_recent.es6.jsx
+++ b/app/assets/javascripts/components/sidebar/sidebar_recent.es6.jsx
@@ -45,7 +45,7 @@ class SidebarRecent extends Component {
   render() {
     return (
       <Clickable
-        content
+        content>
       </Clickable>
     );
   }


### PR DESCRIPTION
The main students page errors on compilation before this fix. I'm sure something other than this is supposed to go here... 