### PR TITLE
Add Group Model

### DIFF
--- a/app/controllers/api/groups_controller.rb
+++ b/app/controllers/api/groups_controller.rb
@@ -4,6 +4,8 @@ class Api::GroupsController < Api::BaseController
     group = Group.new group_params
     if group.save
       render json: group, serializer: GroupBaseSerializer
+    else
+      unprocessable_response group
     end
   end
 

--- a/app/controllers/api/groups_controller.rb
+++ b/app/controllers/api/groups_controller.rb
@@ -1,0 +1,30 @@
+class Api::GroupsController < Api::BaseController
+
+  def create
+    group = Group.new group_params
+    if group.save
+      render json: group, serializer: GroupBaseSerializer
+    end
+  end
+
+  def index
+    groups = Group.all
+    render json: groups, each_serializer: GroupIndexSerializer
+  end
+
+  def show
+    group = Group.find params[:id]
+    render json: group, serializer: GroupIndexSerializer
+  end
+
+  private
+
+  def group_params
+    params.require(:group).permit(
+      :id,
+      :name,
+      :conference_id,
+    )
+  end
+
+end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: groups
+#
+#  id            :integer          not null, primary key
+#  name          :string
+#  conference_id :integer
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#
+
 class Group < ActiveRecord::Base
   belongs_to :conference
 

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,0 +1,5 @@
+class Group < ActiveRecord::Base
+  belongs_to :conference
+
+  has_many :students
+end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -10,7 +10,9 @@
 #
 
 class Group < ActiveRecord::Base
+
   belongs_to :conference
 
   has_many :students
+
 end

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -27,6 +27,7 @@ class Student < ActiveRecord::Base
   multisearchable against: [:first_name, :last_name, :email]
 
   belongs_to :school
+  belongs_to :group
 
   has_many :comments, dependent: :destroy
   has_many :visits, dependent: :destroy, as: :visitable

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -27,8 +27,8 @@ class Student < ActiveRecord::Base
   include PgSearch
   multisearchable against: [:first_name, :last_name, :email]
 
-  belongs_to :school
   belongs_to :group
+  belongs_to :school
 
   has_many :comments, dependent: :destroy
   has_many :visits, dependent: :destroy, as: :visitable

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -17,7 +17,7 @@
 #  home_phone         :string           not null
 #  last_name          :string           not null
 #  school_id          :integer
-#  conference_id      :integer
+#  group_id           :integer
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
 #

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -17,6 +17,7 @@
 #  home_phone         :string           not null
 #  last_name          :string           not null
 #  school_id          :integer
+#  conference_id      :integer
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
 #

--- a/app/serializers/group_base_serializer.rb
+++ b/app/serializers/group_base_serializer.rb
@@ -1,0 +1,5 @@
+class GroupBaseSerialzier < BaseSerializer
+
+  attributes :id, :name
+
+end

--- a/app/serializers/group_base_serializer.rb
+++ b/app/serializers/group_base_serializer.rb
@@ -1,4 +1,4 @@
-class GroupBaseSerialzier < BaseSerializer
+class GroupBaseSerializer < BaseSerializer
 
   attributes :id, :name
 

--- a/app/serializers/group_index_serializer.rb
+++ b/app/serializers/group_index_serializer.rb
@@ -1,0 +1,5 @@
+class GroupIndexSerializer < GroupBaseSerializer
+
+  has_many :students, serializer: StudentBaseSerializer
+
+end

--- a/app/serializers/student_index_serializer.rb
+++ b/app/serializers/student_index_serializer.rb
@@ -1,5 +1,6 @@
 class StudentIndexSerializer < StudentBaseSerializer
 
   belongs_to :school, serializer: SchoolBaseSerializer
+  belongs_to :group, serializer: GroupBaseSerializer
 
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,7 @@
 
     get '/users/profile', to: 'users#profile'
 
+    resources :groups, only: [:create, :index, :show]
     resources :schools, only: [:create, :index, :show, :update]
     resources :students, only: [:create, :index, :show, :update] do
       scope module: :students do

--- a/db/migrate/20151024234240_create_students.rb
+++ b/db/migrate/20151024234240_create_students.rb
@@ -17,6 +17,7 @@ class CreateStudents < ActiveRecord::Migration
       t.string :last_name, null: false
 
       t.references :school, index: true
+      t.references :conference, index: true
 
       t.timestamps null: false
     end

--- a/db/migrate/20151024234240_create_students.rb
+++ b/db/migrate/20151024234240_create_students.rb
@@ -16,8 +16,8 @@ class CreateStudents < ActiveRecord::Migration
       t.string :home_phone, null: false
       t.string :last_name, null: false
 
-      t.references :school, index: true
       t.references :group, index: true
+      t.references :school, index: true
 
       t.timestamps null: false
     end

--- a/db/migrate/20151024234240_create_students.rb
+++ b/db/migrate/20151024234240_create_students.rb
@@ -17,7 +17,7 @@ class CreateStudents < ActiveRecord::Migration
       t.string :last_name, null: false
 
       t.references :school, index: true
-      t.references :conference, index: true
+      t.references :group, index: true
 
       t.timestamps null: false
     end

--- a/db/migrate/20151130013648_create_groups.rb
+++ b/db/migrate/20151130013648_create_groups.rb
@@ -1,0 +1,10 @@
+class CreateGroups < ActiveRecord::Migration
+  def change
+    create_table :groups do |t|
+      t.string :name
+      t.references :conference, index: true
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20151130013648_create_groups.rb
+++ b/db/migrate/20151130013648_create_groups.rb
@@ -1,8 +1,9 @@
 class CreateGroups < ActiveRecord::Migration
   def change
     create_table :groups do |t|
-      t.string :name
-      t.references :conference, index: true
+      t.string :name, null: false
+
+      t.references :conference, index: true, null: false
 
       t.timestamps null: false
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -39,8 +39,8 @@ ActiveRecord::Schema.define(version: 20151130013648) do
   end
 
   create_table "groups", force: :cascade do |t|
-    t.string   "name"
-    t.integer  "conference_id"
+    t.string   "name",          null: false
+    t.integer  "conference_id", null: false
     t.datetime "created_at",    null: false
     t.datetime "updated_at",    null: false
   end
@@ -102,8 +102,8 @@ ActiveRecord::Schema.define(version: 20151130013648) do
     t.string   "home_address",       null: false
     t.string   "home_phone",         null: false
     t.string   "last_name",          null: false
-    t.integer  "school_id"
     t.integer  "group_id"
+    t.integer  "school_id"
     t.datetime "created_at",         null: false
     t.datetime "updated_at",         null: false
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151125043449) do
+ActiveRecord::Schema.define(version: 20151130013648) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -37,6 +37,15 @@ ActiveRecord::Schema.define(version: 20151125043449) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
+
+  create_table "groups", force: :cascade do |t|
+    t.string   "name"
+    t.integer  "conference_id"
+    t.datetime "created_at",    null: false
+    t.datetime "updated_at",    null: false
+  end
+
+  add_index "groups", ["conference_id"], name: "index_groups_on_conference_id", using: :btree
 
   create_table "pg_search_documents", force: :cascade do |t|
     t.text     "content"
@@ -94,10 +103,12 @@ ActiveRecord::Schema.define(version: 20151125043449) do
     t.string   "home_phone",         null: false
     t.string   "last_name",          null: false
     t.integer  "school_id"
+    t.integer  "conference_id"
     t.datetime "created_at",         null: false
     t.datetime "updated_at",         null: false
   end
 
+  add_index "students", ["conference_id"], name: "index_students_on_conference_id", using: :btree
   add_index "students", ["school_id"], name: "index_students_on_school_id", using: :btree
 
   create_table "users", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -103,12 +103,12 @@ ActiveRecord::Schema.define(version: 20151130013648) do
     t.string   "home_phone",         null: false
     t.string   "last_name",          null: false
     t.integer  "school_id"
-    t.integer  "conference_id"
+    t.integer  "group_id"
     t.datetime "created_at",         null: false
     t.datetime "updated_at",         null: false
   end
 
-  add_index "students", ["conference_id"], name: "index_students_on_conference_id", using: :btree
+  add_index "students", ["group_id"], name: "index_students_on_group_id", using: :btree
   add_index "students", ["school_id"], name: "index_students_on_school_id", using: :btree
 
   create_table "users", force: :cascade do |t|

--- a/db/seeds/development/7_groups.rb
+++ b/db/seeds/development/7_groups.rb
@@ -9,7 +9,7 @@ end
 
 (1..5).each do
   generate_group(1)
-  puts "Created group for Conference 1"
+  puts 'Created group for Conference 1.'
 end
 
 Student.all.each do |student|

--- a/db/seeds/development/7_groups.rb
+++ b/db/seeds/development/7_groups.rb
@@ -1,18 +1,20 @@
 @alphabet = ("a".."z").to_a
 
-def generate_group(conference_id)
+def generate_group(conference)
   new_group = Group.create(
     name: @alphabet.shift,
-    conference_id: conference_id,
+    conference: conference,
   )
 end
 
 (1..5).each do
-  generate_group(1)
+  generate_group(Conference.first)
   puts 'Created group for Conference 1.'
 end
 
 Student.all.each do |student|
-  student.group = Group.find(rand(1..5))
-  puts "Assigned group to #{student.first_name} #{student.last_name}."
+  group = Group.find(rand(1..5))
+  student.group = group
+  student.save
+  puts "Assigned #{student.first_name} #{student.last_name} to group #{group.name}."
 end

--- a/db/seeds/development/7_groups.rb
+++ b/db/seeds/development/7_groups.rb
@@ -1,0 +1,18 @@
+@alphabet = ("a".."z").to_a
+
+def generate_group(conference_id)
+  new_group = Group.create(
+    name: @alphabet.shift,
+    conference_id: conference_id,
+  )
+end
+
+(1..5).each do
+  generate_group(1)
+  puts "Created group for Conference 1"
+end
+
+Student.all.each do |student|
+  student.group = Group.find(rand(1..5))
+  puts "Assigned group to #{student.first_name} #{student.last_name}."
+end

--- a/spec/factories/groups.rb
+++ b/spec/factories/groups.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: groups
+#
+#  id            :integer          not null, primary key
+#  name          :string
+#  conference_id :integer
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#
+
 FactoryGirl.define do
   factory :group do
     name {Faker::Team.name}

--- a/spec/factories/groups.rb
+++ b/spec/factories/groups.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :group do
+    name {Faker::Team.name}
+  end
+
+end

--- a/spec/factories/students.rb
+++ b/spec/factories/students.rb
@@ -17,7 +17,7 @@
 #  home_phone         :string           not null
 #  last_name          :string           not null
 #  school_id          :integer
-#  conference_id      :integer
+#  group_id           :integer
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
 #

--- a/spec/factories/students.rb
+++ b/spec/factories/students.rb
@@ -17,6 +17,7 @@
 #  home_phone         :string           not null
 #  last_name          :string           not null
 #  school_id          :integer
+#  conference_id      :integer
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
 #

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Group, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: groups
+#
+#  id            :integer          not null, primary key
+#  name          :string
+#  conference_id :integer
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#
+
 require 'rails_helper'
 
 RSpec.describe Group, type: :model do

--- a/spec/models/student_spec.rb
+++ b/spec/models/student_spec.rb
@@ -17,7 +17,7 @@
 #  home_phone         :string           not null
 #  last_name          :string           not null
 #  school_id          :integer
-#  conference_id      :integer
+#  group_id           :integer
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
 #

--- a/spec/models/student_spec.rb
+++ b/spec/models/student_spec.rb
@@ -17,6 +17,7 @@
 #  home_phone         :string           not null
 #  last_name          :string           not null
 #  school_id          :integer
+#  conference_id      :integer
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
 #


### PR DESCRIPTION
Fix #474
Fix #473
Fix #474
Fix #536

Tests: 
Hit the groups api endpoint, here are the serialized results: 
<img width="648" alt="screen shot 2015-11-29 at 6 53 23 pm" src="https://cloud.githubusercontent.com/assets/3267539/11462556/e2076d9c-96ca-11e5-8940-c8e5ecbabf24.png">


I've made changes to the student migration, so make sure to run `rake:db drop`, etc.

Some thoughts: 

1. We can determine the student conference through the group model, so perhaps we can get rid of the `student_conference` model, and use `though: group` instead. 

2. Since groups should have a user as the counsellor (or whatever they call them at edge), we can determine user responsibilties through the group model too. Perhaps a user `has_many responsibilities: through group`. 

The above two are not included in this PR, but I can add them. 