### PR TITLE
Set up initial infrastructure for student edit errors and refactor student children and edit counterparts 

### DIFF
--- a/app/assets/javascripts/actions/student_actions.es6.jsx
+++ b/app/assets/javascripts/actions/student_actions.es6.jsx
@@ -36,7 +36,10 @@
       };
     }
 
-    updateStudent(id, params) {
+    updateStudent(template) {
+      var id = template.id;
+      delete template.id;
+      var params = { student: template };
       var resolve = (response) => this.storeStudent(response);
       Requester.update(ApiConstants.students.update(id), params, resolve);
       return true;

--- a/app/assets/javascripts/actions/student_actions.es6.jsx
+++ b/app/assets/javascripts/actions/student_actions.es6.jsx
@@ -36,9 +36,15 @@
       };
     }
 
-    updateStudent(template) {
+    updateStudent(student, template) {
       var id = template.id;
       delete template.id;
+      Object.keys(template).map((key) => {
+        if (typeof(template[key]) === 'object' ||
+            student[key] === template[key]) {
+          delete template[key];
+        }
+      });
       var params = { student: template };
       var resolve = (response) => this.storeStudent(response);
       Requester.update(ApiConstants.students.update(id), params, resolve);

--- a/app/assets/javascripts/actions/student_actions.es6.jsx
+++ b/app/assets/javascripts/actions/student_actions.es6.jsx
@@ -4,6 +4,7 @@
     constructor() {
       this.generateActions(
         'storeComment',
+        'storeError',
         'storeStudent',
         'toggleSidebar'
       );
@@ -38,16 +39,19 @@
 
     updateStudent(student, template) {
       var id = template.id;
-      delete template.id;
-      Object.keys(template).map((key) => {
-        if (typeof(template[key]) === 'object' ||
-            student[key] === template[key]) {
-          delete template[key];
+      var attributes = Object.assign({}, template);
+      Object.keys(attributes).map((key) => {
+        if (typeof(attributes[key]) === 'object' ||
+            student[key] === attributes[key]) {
+          delete attributes[key];
         }
       });
-      var params = { student: template };
+      // TOOD(Warren): Set up error as errors object with server.
+      delete attributes.error;
+      var params = { student: attributes };
       var resolve = (response) => this.storeStudent(response);
-      Requester.update(ApiConstants.students.update(id), params, resolve);
+      var reject = (response) => this.storeError(response);
+      Requester.update(ApiConstants.students.update(id), params, resolve, reject);
       return true;
     }
   }

--- a/app/assets/javascripts/actions/student_actions.es6.jsx
+++ b/app/assets/javascripts/actions/student_actions.es6.jsx
@@ -29,6 +29,13 @@
       };
     }
 
+    storeTemplate(key, value) {
+      return {
+        key: key,
+        value: value,
+      };
+    }
+
     updateStudent(id, params) {
       var resolve = (response) => this.storeStudent(response);
       Requester.update(ApiConstants.students.update(id), params, resolve);

--- a/app/assets/javascripts/actions/student_actions.es6.jsx
+++ b/app/assets/javascripts/actions/student_actions.es6.jsx
@@ -21,18 +21,18 @@
       return true;
     }
 
+    storeAttribute(key, value) {
+      return {
+        key: key,
+        value: value,
+      };
+    }
+
     storeOverlay(active, type, target) {
       return {
         active: active,
         target: target,
         type: type,
-      };
-    }
-
-    storeTemplate(key, value) {
-      return {
-        key: key,
-        value: value,
       };
     }
 

--- a/app/assets/javascripts/components/card/card_input.es6.jsx
+++ b/app/assets/javascripts/components/card/card_input.es6.jsx
@@ -6,8 +6,15 @@ class CardInput extends Component {
   static get propTypes() {
     return {
       action: React.PropTypes.func.isRequired,
+      margin: React.PropTypes.bool,
       placeholder: React.PropTypes.string.isRequired,
       value: React.PropTypes.string.isRequired,
+    };
+  }
+
+  static get defaultProps() {
+    return {
+      margin: true,
     };
   }
 
@@ -16,12 +23,13 @@ class CardInput extends Component {
   // --------------------------------------------------
   get styles() {
     return {
-      container: {
-        display: 'flex',
-        alignSelf: 'stretch',
-        padding: '0px 12px',
-        marginTop: '18px',
-      },
+      container: Object.assign(
+        {
+          display: 'flex',
+          alignSelf: 'stretch',
+        },
+        this.props.margin && { marginTop: '18px' }
+      ),
       input: {
         flex: '1',
         padding: '8px',

--- a/app/assets/javascripts/components/student/student_conference.es6.jsx
+++ b/app/assets/javascripts/components/student/student_conference.es6.jsx
@@ -10,28 +10,12 @@ class StudentConference extends Component {
   }
 
   // --------------------------------------------------
-  // Styles
-  // --------------------------------------------------
-  get styles() {
-    return {
-      container: {
-        display: 'flex',
-        flexFlow: 'column',
-        flex: '1',
-        padding: '18px',
-      },
-    };
-  }
-
-  // --------------------------------------------------
   // Render
   // --------------------------------------------------
-  // TODO: Add Student status and Rooming information.
   render() {
-    var conference = this.props.student.group.conference;
     var group = this.props.student.group;
     return (
-      <div style={this.styles.container}>
+      <div style={StyleConstants.cards.body}>
         <h4>{'Status'}</h4>
         <br />
         <h4>{'Group'}</h4>

--- a/app/assets/javascripts/components/student/student_contact.es6.jsx
+++ b/app/assets/javascripts/components/student/student_contact.es6.jsx
@@ -10,39 +10,25 @@ class StudentContact extends Component {
   }
 
   // --------------------------------------------------
-  // Styles
-  // --------------------------------------------------
-  get styles() {
-    return {
-      container: {
-        display: 'flex',
-        flexFlow: 'column',
-        flex: '1',
-        padding: '18px',
-      },
-    };
-  }
-
-  // --------------------------------------------------
   // Render
   // --------------------------------------------------
   render() {
     var student = this.props.student;
     return (
-        <div style={this.styles.container}>
-          <h4>{'Contact'}</h4>
-          <h6>{student.email}</h6>
-          <h6>{student.cell_phone}</h6>
-          <h6>{student.home_phone}</h6>
-          <h6>{student.home_address}</h6>
-          <br />
-          <h4>{'School'}</h4>
-          <Clickable
-            content={student.school.name}
-            route={RouteConstants.schools.show(student.school.id)}
-            type={'h6'} />
-          <h6>{student.school.address}</h6>
-        </div>
+      <div style={StyleConstants.cards.body}>
+        <h4>{'Contact'}</h4>
+        <h6>{student.email}</h6>
+        <h6>{student.cell_phone}</h6>
+        <h6>{student.home_phone}</h6>
+        <h6>{student.home_address}</h6>
+        <br />
+        <h4>{'School'}</h4>
+        <Clickable
+          content={student.school.name}
+          route={RouteConstants.schools.show(student.school.id)}
+          type={'h6'} />
+        <h6>{student.school.address}</h6>
+      </div>
     );
   }
 }

--- a/app/assets/javascripts/components/student/student_contact.es6.jsx
+++ b/app/assets/javascripts/components/student/student_contact.es6.jsx
@@ -31,9 +31,9 @@ class StudentContact extends Component {
     return (
         <div style={this.styles.container}>
           <h4>{'Contact'}</h4>
+          <h6>{student.email}</h6>
           <h6>{student.cell_phone}</h6>
           <h6>{student.home_phone}</h6>
-          <h6>{student.email}</h6>
           <h6>{student.home_address}</h6>
           <br />
           <h4>{'School'}</h4>

--- a/app/assets/javascripts/components/student/student_contact_edit.es6.jsx
+++ b/app/assets/javascripts/components/student/student_contact_edit.es6.jsx
@@ -32,7 +32,7 @@ class StudentContactEdit extends Component {
   generateHandler(field) {
     var state = {};
     return(event) => {
-      StudentActions.storeTemplate(field, event.target.value);
+      StudentActions.storeAttribute(field, event.target.value);
     };
   }
 

--- a/app/assets/javascripts/components/student/student_contact_edit.es6.jsx
+++ b/app/assets/javascripts/components/student/student_contact_edit.es6.jsx
@@ -11,19 +11,6 @@ class StudentContactEdit extends Component {
   }
 
   // --------------------------------------------------
-  // Styles
-  // --------------------------------------------------
-  get styles() {
-    return {
-      container: {
-        display: 'flex',
-        flexFlow: 'column',
-        padding: '18px',
-      },
-    };
-  }
-
-  // --------------------------------------------------
   // Helpers
   // --------------------------------------------------
   generateHandler(field) {
@@ -39,7 +26,7 @@ class StudentContactEdit extends Component {
   render() {
     var template = this.props.template;
     return (
-      <div style={this.styles.container}>
+      <div style={StyleConstants.cards.body}>
         <CardInput
           action={this.generateHandler('email')}
           margin={false}

--- a/app/assets/javascripts/components/student/student_contact_edit.es6.jsx
+++ b/app/assets/javascripts/components/student/student_contact_edit.es6.jsx
@@ -6,6 +6,7 @@ class StudentContactEdit extends Component {
   static get propTypes() {
     return {
       student: React.PropTypes.object.isRequired,
+      template: React.PropTypes.object.isRequired,
     };
   }
 
@@ -14,44 +15,15 @@ class StudentContactEdit extends Component {
   // --------------------------------------------------
   get styles() {
     return {
-      container: Object.assign(
-        {},
-        StyleConstants.cards.default,
-        {
-          display: 'flex',
-          flexFlow: 'column',
-          justifyContent: 'center',
-          width: '356px',
-        }
-      ),
-      form: {
+      container: {
         display: 'flex',
         flexFlow: 'column',
         justifyContent: 'center',
         alignItems: 'center',
-        flex: '1',
         padding: '18px',
         marginBottom: '18px',
       },
-      image: {
-        width: '152px',
-        height: '152px',
-        marginTop: '18px',
-        borderRadius: '50%',
-      },
     };
-  }
-
-  // --------------------------------------------------
-  // Lifecycle
-  // --------------------------------------------------
-  componentWillMount() {
-    this.setState({
-      cellPhone: this.props.student.cell_phone,
-      email: this.props.student.email,
-      homeAddress: this.props.student.home_address,
-      homePhone: this.props.student.home_phone,
-    });
   }
 
   // --------------------------------------------------
@@ -60,52 +32,33 @@ class StudentContactEdit extends Component {
   generateHandler(field) {
     var state = {};
     return(event) => {
-      state[field] = event.target.value;
-      this.setState(state);
+      StudentActions.storeTemplate(field, event.target.value);
     };
-  }
-
-  updateStudent() {
-    var params = {
-      student: {
-        cell_phone: this.state.cellPhone,
-        email: this.state.email,
-        home_address: this.state.homeAddress,
-        home_phone: this.state.homePhone,
-      },
-    };
-    StudentActions.updateStudent(this.props.student.id, params);
   }
 
   // --------------------------------------------------
   // Render
   // --------------------------------------------------
   render() {
-    var student = this.props.student;
+    var template = this.props.template;
     return (
       <div style={this.styles.container}>
-        <CardHeader
-          action={() => this.updateStudent()}
-          content={'Student Information'}
-          icon={TypeConstants.icons.save} />
-        <div style={this.styles.form}>
-          <CardInput
-            action={this.generateHandler('cellPhone')}
-            placeholder={'Cell phone'}
-            value={this.state.cellPhone} />
-          <CardInput
-            action={this.generateHandler('homePhone')}
-            placeholder={'Home phone'}
-            value={this.state.homePhone} />
-          <CardInput
-            action={this.generateHandler('email')}
-            placeholder={'Email'}
-            value={this.state.email} />
-          <CardInput
-            action={this.generateHandler('homeAddress')}
-            placeholder={'Home address'}
-            value={this.state.homeAddress} />
-        </div>
+        <CardInput
+          action={this.generateHandler('email')}
+          placeholder={'Email'}
+          value={template.email} />
+        <CardInput
+          action={this.generateHandler('cell_phone')}
+          placeholder={'Cell phone'}
+          value={template.cell_phone} />
+        <CardInput
+          action={this.generateHandler('home_phone')}
+          placeholder={'Home phone'}
+          value={template.home_phone} />
+        <CardInput
+          action={this.generateHandler('home_address')}
+          placeholder={'Home address'}
+          value={template.home_address} />
       </div>
     );
   }

--- a/app/assets/javascripts/components/student/student_contact_edit.es6.jsx
+++ b/app/assets/javascripts/components/student/student_contact_edit.es6.jsx
@@ -18,10 +18,7 @@ class StudentContactEdit extends Component {
       container: {
         display: 'flex',
         flexFlow: 'column',
-        justifyContent: 'center',
-        alignItems: 'center',
         padding: '18px',
-        marginBottom: '18px',
       },
     };
   }
@@ -45,6 +42,7 @@ class StudentContactEdit extends Component {
       <div style={this.styles.container}>
         <CardInput
           action={this.generateHandler('email')}
+          margin={false}
           placeholder={'Email'}
           value={template.email} />
         <CardInput

--- a/app/assets/javascripts/components/student/student_edit_modal.es6.jsx
+++ b/app/assets/javascripts/components/student/student_edit_modal.es6.jsx
@@ -29,9 +29,21 @@ class StudentEditModal extends EditModal {
   renderBody() {
     switch (this.props.overlay.target) {
       case TypeConstants.overlay.target.preview:
-        return <StudentPreviewEdit student={this.props.student} />;
+        return (
+          <div style={this.styles.section}>
+            <CardHeader
+              action={() => StudentActions.updateStudent(this.props.template)}
+              content={'Student Preview'}
+              icon={TypeConstants.icons.save} />
+            <StudentPreviewEdit
+              student={this.props.student}
+              template={this.props.template} />
+          </div>
+        );
       case TypeConstants.overlay.target.contact:
-        return <StudentContactEdit student={this.props.student} />;
+        return (
+          <StudentContactEdit student={this.props.student} />
+        );
       case TypeConstants.overlay.target.guardian:
         return <StudentGuardianEdit student={this.props.student} />;
       case TypeConstants.overlay.target.outreach:

--- a/app/assets/javascripts/components/student/student_edit_modal.es6.jsx
+++ b/app/assets/javascripts/components/student/student_edit_modal.es6.jsx
@@ -11,6 +11,7 @@ class StudentEditModal extends EditModal {
         type: React.PropTypes.string.isRequired,
       }).isRequired,
       student: React.PropTypes.object.isRequired,
+      template: React.PropTypes.object.isRequired,
     };
   }
 
@@ -24,6 +25,16 @@ class StudentEditModal extends EditModal {
   }
 
   // --------------------------------------------------
+  // Helpers
+  // --------------------------------------------------
+  updateStudent() {
+    StudentActions.updateStudent(
+      this.props.student,
+      this.props.template
+    );
+  }
+
+  // --------------------------------------------------
   // Render
   // --------------------------------------------------
   renderBody() {
@@ -32,7 +43,7 @@ class StudentEditModal extends EditModal {
         return (
           <div style={this.styles.section}>
             <CardHeader
-              action={() => StudentActions.updateStudent(this.props.template)}
+              action={() => this.updateStudent()}
               content={'Student Preview'}
               icon={TypeConstants.icons.save} />
             <StudentPreviewEdit

--- a/app/assets/javascripts/components/student/student_edit_modal.es6.jsx
+++ b/app/assets/javascripts/components/student/student_edit_modal.es6.jsx
@@ -53,12 +53,40 @@ class StudentEditModal extends EditModal {
         );
       case TypeConstants.overlay.target.contact:
         return (
-          <StudentContactEdit student={this.props.student} />
+          <div style={this.styles.section}>
+            <CardHeader
+              action={() => this.updateStudent()}
+              content={'Student Contact'}
+              icon={TypeConstants.icons.save} />
+            <StudentContactEdit
+              student={this.props.student}
+              template={this.props.template} />
+          </div>
         );
       case TypeConstants.overlay.target.guardian:
-        return <StudentGuardianEdit student={this.props.student} />;
+        return (
+          <div style={this.styles.section}>
+            <CardHeader
+              action={() => this.updateStudent()}
+              content={'Student Guardian'}
+              icon={TypeConstants.icons.save} />
+            <StudentGuardianEdit
+              student={this.props.student}
+              template={this.props.template} />
+          </div>
+        );
       case TypeConstants.overlay.target.outreach:
-        return <StudentOutreachEdit student={this.props.student} />;
+        return (
+          <div style={this.styles.section}>
+            <CardHeader
+              action={() => this.updateStudent()}
+              content={'Student Outreach'}
+              icon={TypeConstants.icons.save} />
+            <StudentOutreachEdit
+              student={this.props.student}
+              template={this.props.template} />
+          </div>
+        );
     }
   }
 }

--- a/app/assets/javascripts/components/student/student_guardian.es6.jsx
+++ b/app/assets/javascripts/components/student/student_guardian.es6.jsx
@@ -10,36 +10,22 @@ class StudentGuardian extends Component {
   }
 
   // --------------------------------------------------
-  // Styles
-  // --------------------------------------------------
-  get styles() {
-    return {
-      container: {
-        display: 'flex',
-        flexFlow: 'column',
-        flex: '1',
-        padding: '18px',
-      },
-    };
-  }
-
-  // --------------------------------------------------
   // Render
   // --------------------------------------------------
   render() {
     var student = this.props.student;
     return (
-        <div style={this.styles.container}>
-          <h4>{'Guardian One'}</h4>
-          <h6>{student.guardian_one_name}</h6>
-          <h6>{student.guardian_one_phone}</h6>
-          <h6>{student.guardian_one_email}</h6>
-          <br />
-          <h4>{'Guardian Two'}</h4>
-          <h6>{student.guardian_two_name}</h6>
-          <h6>{student.guardian_two_phone}</h6>
-          <h6>{student.guardian_two_email}</h6>
-        </div>
+      <div style={StyleConstants.cards.body}>
+        <h4>{'Guardian One'}</h4>
+        <h6>{student.guardian_one_name}</h6>
+        <h6>{student.guardian_one_phone}</h6>
+        <h6>{student.guardian_one_email}</h6>
+        <br />
+        <h4>{'Guardian Two'}</h4>
+        <h6>{student.guardian_two_name}</h6>
+        <h6>{student.guardian_two_phone}</h6>
+        <h6>{student.guardian_two_email}</h6>
+      </div>
     );
   }
 }

--- a/app/assets/javascripts/components/student/student_guardian_edit.es6.jsx
+++ b/app/assets/javascripts/components/student/student_guardian_edit.es6.jsx
@@ -11,19 +11,6 @@ class StudentGuardianEdit extends Component {
   }
 
   // --------------------------------------------------
-  // Styles
-  // --------------------------------------------------
-  get styles() {
-    return {
-      container: {
-        display: 'flex',
-        flexFlow: 'column',
-        padding: '18px',
-      },
-    };
-  }
-
-  // --------------------------------------------------
   // Helpers
   // --------------------------------------------------
   generateHandler(field) {
@@ -39,7 +26,7 @@ class StudentGuardianEdit extends Component {
   render() {
     var template = this.props.template;
     return (
-      <div style={this.styles.container}>
+      <div style={StyleConstants.cards.body}>
         <CardInput
           action={this.generateHandler('guardian_one_name')}
           margin={false}

--- a/app/assets/javascripts/components/student/student_guardian_edit.es6.jsx
+++ b/app/assets/javascripts/components/student/student_guardian_edit.es6.jsx
@@ -6,6 +6,7 @@ class StudentGuardianEdit extends Component {
   static get propTypes() {
     return {
       student: React.PropTypes.object.isRequired,
+      template: React.PropTypes.object.isRequired,
     };
   }
 
@@ -14,17 +15,7 @@ class StudentGuardianEdit extends Component {
   // --------------------------------------------------
   get styles() {
     return {
-      container: Object.assign(
-        {},
-        StyleConstants.cards.default,
-        {
-          display: 'flex',
-          flexFlow: 'column',
-          justifyContent: 'center',
-          width: '356px',
-        }
-      ),
-      form: {
+      container: {
         display: 'flex',
         flexFlow: 'column',
         justifyContent: 'center',
@@ -36,81 +27,46 @@ class StudentGuardianEdit extends Component {
   }
 
   // --------------------------------------------------
-  // Lifecycle
-  // --------------------------------------------------
-  componentWillMount() {
-    this.setState({
-      guardianOneName: this.props.student.guardian_one_name,
-      guardianOnePhone: this.props.student.guardian_one_phone,
-      guardianOneEmail: this.props.student.guardian_one_email,
-      guardianTwoName: this.props.student.guardian_two_name,
-      guardianTwoPhone: this.props.student.guardian_two_phone,
-      guardianTwoEmail: this.props.student.guardian_two_email,
-    });
-  }
-
-  // --------------------------------------------------
   // Helpers
   // --------------------------------------------------
   generateHandler(field) {
     var state = {};
     return(event) => {
-      state[field] = event.target.value;
-      this.setState(state);
+      StudentActions.storeTemplate(field, event.target.value);
     };
-  }
-
-  updateStudent() {
-    var params = {
-      student: {
-        guardian_one_name: this.state.guardianOneName,
-        guardian_one_phone: this.state.guardianOnePhone,
-        guardian_one_email: this.state.guardianOneEmail,
-        guardian_two_name: this.state.guardianTwoName,
-        guardian_two_phone: this.state.guardianTwoPhone,
-        guardian_two_email: this.state.guardianTwoEmail,
-      },
-    };
-    StudentActions.updateStudent(this.props.student.id, params);
   }
 
   // --------------------------------------------------
   // Render
   // --------------------------------------------------
   render() {
-    var student = this.props.student;
+    var template = this.props.template;
     return (
       <div style={this.styles.container}>
-        <CardHeader
-          action={() => this.updateStudent()}
-          content={'Guardian Information'}
-          icon={TypeConstants.icons.save} />
-        <div style={this.styles.form}>
-          <CardInput
-            action={this.generateHandler('guardianOneName')}
-            placeholder={'Guardian One Name'}
-            value={this.state.guardianOneName} />
-          <CardInput
-            action={this.generateHandler('guardianOnePhone')}
-            placeholder={'Guardian One Phone'}
-            value={this.state.guardianOnePhone} />
-          <CardInput
-            action={this.generateHandler('guardianOneEmail')}
-            placeholder={'Guardian One Email'}
-            value={this.state.guardianOneEmail} />
-          <CardInput
-            action={this.generateHandler('guardianTwoName')}
-            placeholder={'Guardian Two Name'}
-            value={this.state.guardianTwoName} />
-          <CardInput
-            action={this.generateHandler('guardianTwoPhone')}
-            placeholder={'Guardian Two Phone'}
-            value={this.state.guardianTwoPhone} />
-          <CardInput
-            action={this.generateHandler('guardianTwoEmail')}
-            placeholder={'Guardian Two Email'}
-            value={this.state.guardianTwoEmail} />
-        </div>
+        <CardInput
+          action={this.generateHandler('guardian_one_name')}
+          placeholder={'Guardian one name'}
+          value={template.guardian_one_name} />
+        <CardInput
+          action={this.generateHandler('guardian_one_phone')}
+          placeholder={'Guardian one phone'}
+          value={template.guardian_one_phone} />
+        <CardInput
+          action={this.generateHandler('guardian_one_email')}
+          placeholder={'Guardian one email'}
+          value={template.guardian_one_email} />
+        <CardInput
+          action={this.generateHandler('guardian_two_name')}
+          placeholder={'Guardian two name'}
+          value={template.guardian_two_name} />
+        <CardInput
+          action={this.generateHandler('guardian_two_phone')}
+          placeholder={'Guardian two phone'}
+          value={template.guardian_two_phone} />
+        <CardInput
+          action={this.generateHandler('guardian_two_email')}
+          placeholder={'Guardian two email'}
+          value={template.guardian_two_email} />
       </div>
     );
   }

--- a/app/assets/javascripts/components/student/student_guardian_edit.es6.jsx
+++ b/app/assets/javascripts/components/student/student_guardian_edit.es6.jsx
@@ -18,10 +18,7 @@ class StudentGuardianEdit extends Component {
       container: {
         display: 'flex',
         flexFlow: 'column',
-        justifyContent: 'center',
-        alignItems: 'center',
         padding: '18px',
-        marginBottom: '18px',
       },
     };
   }
@@ -45,6 +42,7 @@ class StudentGuardianEdit extends Component {
       <div style={this.styles.container}>
         <CardInput
           action={this.generateHandler('guardian_one_name')}
+          margin={false}
           placeholder={'Guardian one name'}
           value={template.guardian_one_name} />
         <CardInput

--- a/app/assets/javascripts/components/student/student_guardian_edit.es6.jsx
+++ b/app/assets/javascripts/components/student/student_guardian_edit.es6.jsx
@@ -32,7 +32,7 @@ class StudentGuardianEdit extends Component {
   generateHandler(field) {
     var state = {};
     return(event) => {
-      StudentActions.storeTemplate(field, event.target.value);
+      StudentActions.storeAttribute(field, event.target.value);
     };
   }
 

--- a/app/assets/javascripts/components/student/student_outreach.es6.jsx
+++ b/app/assets/javascripts/components/student/student_outreach.es6.jsx
@@ -9,26 +9,6 @@ class StudentOutreach extends Component {
     };
   }
 
-  static get defaultProps() {
-    return {
-      student: {}
-    };
-  }
-
-  // --------------------------------------------------
-  // Styles
-  // --------------------------------------------------
-  get styles() {
-    return {
-      container: {
-        display: 'flex',
-        flexFlow: 'column',
-        flex: '1',
-        padding: '18px',
-      },
-    };
-  }
-
   // --------------------------------------------------
   // Render
   // --------------------------------------------------
@@ -45,7 +25,7 @@ class StudentOutreach extends Component {
   }
   render() {
     return (
-      <div style={this.styles.container}>
+      <div style={StyleConstants.cards.body}>
         {this.renderResponsibility()}
       </div>
     );

--- a/app/assets/javascripts/components/student/student_page.es6.jsx
+++ b/app/assets/javascripts/components/student/student_page.es6.jsx
@@ -70,7 +70,8 @@ class StudentPage extends Component {
         <StudentPageOverlay
           overlay={this.state.overlay}
           profile={this.state.profile}
-          student={this.state.student} />
+          student={this.state.student}
+          template={this.state.template} />
       );
     }
   }

--- a/app/assets/javascripts/components/student/student_page_overlay.es6.jsx
+++ b/app/assets/javascripts/components/student/student_page_overlay.es6.jsx
@@ -12,6 +12,7 @@ class StudentPageOverlay extends PageOverlay {
       }).isRequired,
       profile: React.PropTypes.object.isRequired,
       student: React.PropTypes.object.isRequired,
+      template: React.PropTypes.object.isRequired,
     };
   }
 
@@ -32,7 +33,8 @@ class StudentPageOverlay extends PageOverlay {
       return (
         <StudentEditModal
           overlay={this.props.overlay}
-          student={this.props.student} />
+          student={this.props.student}
+          template={this.props.template} />
       );
     } else {
       return (

--- a/app/assets/javascripts/components/student/student_preview.es6.jsx
+++ b/app/assets/javascripts/components/student/student_preview.es6.jsx
@@ -14,14 +14,11 @@ class StudentPreview extends Component {
   // --------------------------------------------------
   get styles() {
     return {
-      container: {
-        display: 'flex',
-        flexFlow: 'column',
-        justifyContent: 'center',
-        alignItems: 'center',
-        flex: '1',
-        padding: '18px',
-      },
+      container: Object.assign(
+        {},
+        StyleConstants.cards.body,
+        { alignItems: 'center' }
+      ),
       image: {
         width: '128px',
         height: '128px',

--- a/app/assets/javascripts/components/student/student_preview_edit.es6.jsx
+++ b/app/assets/javascripts/components/student/student_preview_edit.es6.jsx
@@ -15,12 +15,11 @@ class StudentPreviewEdit extends Component {
   // --------------------------------------------------
   get styles() {
     return {
-      container: {
-        display: 'flex',
-        flexFlow: 'column',
-        alignItems: 'center',
-        padding: '18px',
-      },
+      container: Object.assign(
+        {},
+        StyleConstants.cards.body,
+        { alignItems: 'center' }
+      ),
       image: {
         width: '128px',
         height: '128px',

--- a/app/assets/javascripts/components/student/student_preview_edit.es6.jsx
+++ b/app/assets/javascripts/components/student/student_preview_edit.es6.jsx
@@ -14,17 +14,7 @@ class StudentPreviewEdit extends Component {
   // --------------------------------------------------
   get styles() {
     return {
-      container: Object.assign(
-        {},
-        StyleConstants.cards.default,
-        {
-          display: 'flex',
-          flexFlow: 'column',
-          justifyContent: 'center',
-          width: '356px',
-        }
-      ),
-      form: {
+      container: {
         display: 'flex',
         flexFlow: 'column',
         justifyContent: 'center',
@@ -57,8 +47,7 @@ class StudentPreviewEdit extends Component {
   generateHandler(field) {
     var state = {};
     return(event) => {
-      state[field] = event.target.value;
-      this.setState(state);
+      StudentActions.storeTemplate(field, event.target.value);
     };
   }
 
@@ -77,30 +66,24 @@ class StudentPreviewEdit extends Component {
   // Render
   // --------------------------------------------------
   render() {
-    var student = this.props.student;
+    var template = this.props.template;
     return (
       <div style={this.styles.container}>
-        <CardHeader
-          action={() => this.updateStudent()}
-          content={'Student Preview'}
-          icon={TypeConstants.icons.save} />
-        <div style={this.styles.form}>
-          <img
-            src='https://scontent.fsnc1-1.fna.fbcdn.net/hphotos-xfp1/t31.0-8/11856297_10200932572512494_2256826043885795533_o.jpg'
-            style={this.styles.image} />
-          <CardInput
-            action={this.generateHandler('firstName')}
-            placeholder={'First name'}
-            value={this.state.firstName} />
-          <CardInput
-            action={this.generateHandler('lastName')}
-            placeholder={'Last name'}
-            value={this.state.lastName} />
-          <CardInput
-            action={this.generateHandler('birthday')}
-            placeholder={'Birthday'}
-            value={this.state.birthday} />
-        </div>
+        <img
+          src={'https://scontent.fsnc1-1.fna.fbcdn.net/hphotos-xfp1/t31.0-8/11856297_10200932572512494_2256826043885795533_o.jpg'}
+          style={this.styles.image} />
+        <CardInput
+          action={this.generateHandler('first_name')}
+          placeholder={'First name'}
+          value={template.first_name} />
+        <CardInput
+          action={this.generateHandler('last_name')}
+          placeholder={'Last name'}
+          value={template.last_name} />
+        <CardInput
+          action={this.generateHandler('birthday')}
+          placeholder={'Birthday'}
+          value={template.birthday} />
       </div>
     );
   }

--- a/app/assets/javascripts/components/student/student_preview_edit.es6.jsx
+++ b/app/assets/javascripts/components/student/student_preview_edit.es6.jsx
@@ -18,10 +18,8 @@ class StudentPreviewEdit extends Component {
       container: {
         display: 'flex',
         flexFlow: 'column',
-        justifyContent: 'center',
         alignItems: 'center',
         padding: '18px',
-        marginBottom: '18px',
       },
       image: {
         width: '128px',

--- a/app/assets/javascripts/components/student/student_preview_edit.es6.jsx
+++ b/app/assets/javascripts/components/student/student_preview_edit.es6.jsx
@@ -6,6 +6,7 @@ class StudentPreviewEdit extends Component {
   static get propTypes() {
     return {
       student: React.PropTypes.object.isRequired,
+      template: React.PropTypes.object.isRequired,
     };
   }
 
@@ -31,17 +32,6 @@ class StudentPreviewEdit extends Component {
   }
 
   // --------------------------------------------------
-  // Lifecycle
-  // --------------------------------------------------
-  componentWillMount() {
-    this.setState({
-      birthday: this.props.student.birthday,
-      firstName: this.props.student.first_name,
-      lastName: this.props.student.last_name,
-    });
-  }
-
-  // --------------------------------------------------
   // Helpers
   // --------------------------------------------------
   generateHandler(field) {
@@ -49,17 +39,6 @@ class StudentPreviewEdit extends Component {
     return(event) => {
       StudentActions.storeTemplate(field, event.target.value);
     };
-  }
-
-  updateStudent() {
-    var params = {
-      student: {
-        birthday: this.state.birthday,
-        first_name: this.state.firstName,
-        last_name: this.state.lastName,
-      },
-    };
-    StudentActions.updateStudent(this.props.student.id, params);
   }
 
   // --------------------------------------------------

--- a/app/assets/javascripts/components/student/student_preview_edit.es6.jsx
+++ b/app/assets/javascripts/components/student/student_preview_edit.es6.jsx
@@ -37,7 +37,7 @@ class StudentPreviewEdit extends Component {
   generateHandler(field) {
     var state = {};
     return(event) => {
-      StudentActions.storeTemplate(field, event.target.value);
+      StudentActions.storeAttribute(field, event.target.value);
     };
   }
 

--- a/app/assets/javascripts/constants/style_constants.es6.jsx
+++ b/app/assets/javascripts/constants/style_constants.es6.jsx
@@ -18,6 +18,12 @@
 
     get cards() {
       return {
+        body: {
+          display: 'flex',
+          flexFlow: 'column',
+          flex: '1',
+          padding: '18px',
+        },
         default: {
           backgroundColor: this.colors.white,
           border: '1px solid',

--- a/app/assets/javascripts/stores/student_store.es6.jsx
+++ b/app/assets/javascripts/stores/student_store.es6.jsx
@@ -17,10 +17,15 @@
       this.bindListeners({
         handleStoreAttribute: StudentActions.STORE_ATTRIBUTE,
         handleStoreComment: StudentActions.STORE_COMMENT,
+        handleStoreError: StudentActions.STORE_ERROR,
         handleStoreOverlay: StudentActions.STORE_OVERLAY,
         handleStoreStudent: StudentActions.STORE_STUDENT,
         handleToggleSidebar: StudentActions.TOGGLE_SIDEBAR,
       });
+    }
+
+    handleStoreAttribute(attribute) {
+      this.template[attribute.key] = attribute.value;
     }
 
     handleStoreComment(response) {
@@ -28,18 +33,19 @@
       this.student.comments.push(response.comment);
     }
 
+    handleStoreError(response) {
+      this.template.error = response.message;
+    }
+
     handleStoreOverlay(overlay) {
       this.overlay = overlay;
+      this.template = Object.assign({}, this.student);
     }
 
     handleStoreStudent(response) {
       this.overlay.active = false;
       this.student = response.student;
       this.template = Object.assign({}, this.student);
-    }
-
-    handleStoreAttribute(attribute) {
-      this.template[attribute.key] = attribute.value;
     }
 
     handleToggleSidebar() {

--- a/app/assets/javascripts/stores/student_store.es6.jsx
+++ b/app/assets/javascripts/stores/student_store.es6.jsx
@@ -13,17 +13,19 @@
         group: {},
         school: {},
       };
+      this.template = {};
       this.bindListeners({
         handleStoreComment: StudentActions.STORE_COMMENT,
         handleStoreOverlay: StudentActions.STORE_OVERLAY,
         handleStoreStudent: StudentActions.STORE_STUDENT,
+        handleStoreTemplate: StudentActions.STORE_TEMPLATE,
         handleToggleSidebar: StudentActions.TOGGLE_SIDEBAR,
       });
     }
 
     handleStoreComment(response) {
-      this.student.comments.push(response.comment);
       this.overlay.active = false;
+      this.student.comments.push(response.comment);
     }
 
     handleStoreOverlay(overlay) {
@@ -31,8 +33,14 @@
     }
 
     handleStoreStudent(response) {
-      this.student = response.student;
       this.overlay.active = false;
+      this.student = response.student;
+      this.template = Object.assign({}, this.student);
+    }
+
+    handleStoreTemplate(params) {
+      this.template[params.key] = params.value;
+      console.log(this.template);
     }
 
     handleToggleSidebar() {

--- a/app/assets/javascripts/stores/student_store.es6.jsx
+++ b/app/assets/javascripts/stores/student_store.es6.jsx
@@ -15,10 +15,10 @@
       };
       this.template = {};
       this.bindListeners({
+        handleStoreAttribute: StudentActions.STORE_ATTRIBUTE,
         handleStoreComment: StudentActions.STORE_COMMENT,
         handleStoreOverlay: StudentActions.STORE_OVERLAY,
         handleStoreStudent: StudentActions.STORE_STUDENT,
-        handleStoreTemplate: StudentActions.STORE_TEMPLATE,
         handleToggleSidebar: StudentActions.TOGGLE_SIDEBAR,
       });
     }
@@ -38,9 +38,8 @@
       this.template = Object.assign({}, this.student);
     }
 
-    handleStoreTemplate(params) {
-      this.template[params.key] = params.value;
-      console.log(this.template);
+    handleStoreAttribute(attribute) {
+      this.template[attribute.key] = attribute.value;
     }
 
     handleToggleSidebar() {

--- a/app/assets/javascripts/templates/edit_modal.es6.jsx
+++ b/app/assets/javascripts/templates/edit_modal.es6.jsx
@@ -19,6 +19,16 @@ class EditModal extends Component {
         justifyContent: 'center',
         alignItems: 'center',
       },
+      section: Object.assign(
+        {},
+        StyleConstants.cards.default,
+        {
+          display: 'flex',
+          flexFlow: 'column',
+          justifyContent: 'center',
+          width: '356px',
+        }
+      ),
       title: {
         marginBottom: '6px',
       },


### PR DESCRIPTION
Fix #649 
Fix #652 

This pull request refactors how `Student...Edit` components are rendered by the `StudentEditModal` component. Before, each individual `Student...Edit` component would render its own `CardHeader` component. This pull request move the `CardHeader` component into the `StudentEditModal`.

As well, `Student...Edit` components no longer need a `componentWillMount` lifecycle method. Instead, `input` events in each `Edit` component fire an action and update the `template` object in the `StudentStore`'s state. The `template` object is a duplicate of the `student` object, but can be edited as `edit` `forms` are filled out. Then, when a user fires off a `save` action, this `template` object is used to generate the `params` for the `update` request. Notice now that `updateStudent` is refactored out from the `Student...Edit` components and into the `StudentEditModal` component. That's the beauty of Alt and storing state in stores!

Don't worry too much if you don't understand what's going down in `StudentActions`, it's more important to understand the overall structure moving forward.