### PR TITLE
Optimize api controllers and serializers

### DIFF
--- a/app/assets/javascripts/components/schools/schools_card.es6.jsx
+++ b/app/assets/javascripts/components/schools/schools_card.es6.jsx
@@ -20,9 +20,7 @@ class SchoolsCard extends Component {
           content={school.name}
           route={RouteConstants.schools.show(school.id)}
           type={'h3'} />
-        <h6>{school.address}</h6>
-        <h6>{school.counselor_name}</h6>
-        <h6>{school.counselor_email}</h6>
+        <h6>{school.website}</h6>
       </div>
     );
   }

--- a/app/assets/javascripts/components/student/student_contact.es6.jsx
+++ b/app/assets/javascripts/components/student/student_contact.es6.jsx
@@ -27,7 +27,6 @@ class StudentContact extends Component {
           content={student.school.name}
           route={RouteConstants.schools.show(student.school.id)}
           type={'h6'} />
-        <h6>{student.school.address}</h6>
       </div>
     );
   }

--- a/app/controllers/api/conferences/groups_controller.rb
+++ b/app/controllers/api/conferences/groups_controller.rb
@@ -10,11 +10,12 @@ class Api::Conferences::GroupsController < Api::BaseController
   end
 
   def index
+    groups = Group.all
     render json: Group.all, each_serializer: GroupIndexSerializer
   end
 
   def show
-    group = Group.find params[:id]
+    group = Group.includes(:conference, students: :school).find params[:id]
     render json: group, serializer: GroupShowSerializer
   end
 

--- a/app/controllers/api/conferences_controller.rb
+++ b/app/controllers/api/conferences_controller.rb
@@ -19,12 +19,12 @@ class Api::ConferencesController < Api::BaseController
   end
 
   def show
-    conference = Conference.find params[:id]
+    conference = Conference.includes(:groups).find params[:id]
     render json: conference, serializer: ConferenceShowSerializer
   end
 
   def update
-    conference = Conference.find params[:id]
+    conference = Conference.includes(:groups).find params[:id]
     if conference.update_attributes conference_params
       render json: conference,
              serializer: ConferenceShowSerializer,

--- a/app/controllers/api/forms_controller.rb
+++ b/app/controllers/api/forms_controller.rb
@@ -3,7 +3,7 @@ class Api::FormsController < Api::BaseController
   skip_before_filter :authenticate_user, only: [:show]
 
   def show
-    form = Form.find params[:id]
+    form = Form.includes(sections: :questions).find params[:id]
     render json: form, serializer: FormShowSerializer
   end
 

--- a/app/controllers/api/schools_controller.rb
+++ b/app/controllers/api/schools_controller.rb
@@ -21,7 +21,9 @@ class Api::SchoolsController < Api::BaseController
   def update
     school = School.find params[:id]
     if school.update_attributes school_params
-      render json: school, serializer: SchoolShowSerializer, status: 201
+      render json: school,
+             serializer: SchoolShowSerializer,
+             status: 201
     else
       unprocessable_response school
     end

--- a/app/controllers/api/students/comments_controller.rb
+++ b/app/controllers/api/students/comments_controller.rb
@@ -1,11 +1,12 @@
 class Api::Students::CommentsController < Api::BaseController
 
   def create
-    puts params
     comment = Comment.new comment_params
     comment.student_id = params[:student_id]
     if comment.save
-      render json: comment, serializer: CommentIndexSerializer, status: 201
+      render json: comment,
+             serializer: CommentBaseSerializer,
+             status: 201
     else
       unprocessable_response comment
     end

--- a/app/controllers/api/students_controller.rb
+++ b/app/controllers/api/students_controller.rb
@@ -5,7 +5,9 @@ class Api::StudentsController < Api::BaseController
   def create
     student = Student.new student_params
     if student.save
-      render json: student, serializer: StudentBaseSerializer, status: 201
+      render json: student,
+                   serializer: StudentBaseSerializer,
+                   status: 201
     else
       unprocessable_response student
     end
@@ -33,7 +35,9 @@ class Api::StudentsController < Api::BaseController
   def update
     student = Student.includes(comments: :user).find params[:id]
     if student.update_attributes student_params
-      render json: student, serializer: StudentShowSerializer, status: 201
+      render json: student,
+                   serializer: StudentShowSerializer,
+                   status: 201
     else
       unprocessable_response student
     end

--- a/app/controllers/api/users/registrations_controller.rb
+++ b/app/controllers/api/users/registrations_controller.rb
@@ -8,7 +8,9 @@ class Api::Users::RegistrationsController < Devise::RegistrationsController
     user.skip_confirmation!
     if user.save
       sign_in user
-      render json: user, status: 201
+      render json: user,
+                   serializer: UserBaseSerializer,
+                   status: 201
     else
       unprocessable_response user
     end

--- a/app/controllers/api/users/sessions_controller.rb
+++ b/app/controllers/api/users/sessions_controller.rb
@@ -7,7 +7,9 @@ class Api::Users::SessionsController < Devise::SessionsController
     return invalid_login if user.nil?
     if user.valid_password? params[:user][:password]
       sign_in user
-      render json: user, status: 201
+      render json: user,
+             serializer: UserBaseSerializer,
+             status: 201
     else
       invalid_login
     end

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -12,15 +12,17 @@ class Api::UsersController < Api::BaseController
   end
 
   def show
-    user = User.find params[:id]
+    user = User.includes(:responsibilities).find params[:id]
     current_user.create_visit('User', params[:id].to_i)
     render json: user, serializer: UserShowSerializer
   end
 
   def update
-    user = User.find params[:id]
+    user = User.includes(:responsibilities).find params[:id]
     if user.update_attributes user_params
-      render json: user, serializer: UserIndexSerializer, status: 201
+      render json: user,
+                   serializer: UserShowSerializer,
+                   status: 201
     else
       unprocessable_response user
     end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,11 +1,9 @@
 class PagesController < BaseController
 
+  before_filter :poll_authentication, only: [:login, :signup]
   skip_before_filter :authenticate_user, only: [:login, :signup]
 
   def login
-    if user_signed_in?
-      redirect_to students_path
-    end
   end
 
   def mail
@@ -15,6 +13,11 @@ class PagesController < BaseController
   end
 
   def signup
+  end
+
+  private
+
+  def poll_authentication
     if user_signed_in?
       redirect_to students_path
     end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -30,7 +30,6 @@ class School < ActiveRecord::Base
   validates :address_city, presence: true
   validates :address_one, presence: true
   validates :address_state, presence: true
-  validates :address_two, presence: false
   validates :address_zip, presence: true
   validates :contact_email, presence: true
   validates :contact_first_name, presence: true

--- a/app/serializers/comment_base_serializer.rb
+++ b/app/serializers/comment_base_serializer.rb
@@ -2,5 +2,7 @@ class CommentBaseSerializer < BaseSerializer
 
   attributes :id, :content, :updated_at
 
+  has_one :user, serializer: UserBaseSerializer
+
 end
 

--- a/app/serializers/comment_index_serializer.rb
+++ b/app/serializers/comment_index_serializer.rb
@@ -1,5 +1,0 @@
-class CommentIndexSerializer < CommentBaseSerializer
-
-  has_one :user, serializer: UserBaseSerializer
-
-end

--- a/app/serializers/conference_base_serializer.rb
+++ b/app/serializers/conference_base_serializer.rb
@@ -1,5 +1,5 @@
 class ConferenceBaseSerializer < BaseSerializer
 
-  attributes :id, :end_date, :location, :name, :start_date
+  attributes :id, :name
 
 end

--- a/app/serializers/conference_index_serializer.rb
+++ b/app/serializers/conference_index_serializer.rb
@@ -1,3 +1,5 @@
 class ConferenceIndexSerializer < ConferenceBaseSerializer
 
+  attributes :end_date, :location, :start_date
+
 end

--- a/app/serializers/form_base_serializer.rb
+++ b/app/serializers/form_base_serializer.rb
@@ -1,5 +1,5 @@
 class FormBaseSerializer < BaseSerializer
 
-  attributes :id, :target, :title
+  attributes :id, :title
 
 end

--- a/app/serializers/form_show_serializer.rb
+++ b/app/serializers/form_show_serializer.rb
@@ -1,5 +1,7 @@
 class FormShowSerializer < FormIndexSerializer
 
+  attributes :target
+
   has_many :sections, serializer: SectionBaseSerializer
 
 end

--- a/app/serializers/group_base_serializer.rb
+++ b/app/serializers/group_base_serializer.rb
@@ -1,5 +1,5 @@
 class GroupBaseSerializer < BaseSerializer
 
-  attributes :id, :conference_id, :name, :primary_leader, :secondary_leader
+  attributes :id, :name
 
 end

--- a/app/serializers/group_index_serializer.rb
+++ b/app/serializers/group_index_serializer.rb
@@ -1,3 +1,5 @@
 class GroupIndexSerializer < GroupBaseSerializer
 
+  attributes :conference_id, :primary_leader, :secondary_leader
+
 end

--- a/app/serializers/group_student_serializer.rb
+++ b/app/serializers/group_student_serializer.rb
@@ -1,5 +1,0 @@
-  class GroupStudentSerializer < GroupBaseSerializer
-
-  has_one :conference, serializer: ConferenceBaseSerializer
-
-end

--- a/app/serializers/school_base_serializer.rb
+++ b/app/serializers/school_base_serializer.rb
@@ -1,5 +1,5 @@
 class SchoolBaseSerializer < BaseSerializer
 
-  attributes :id, :address_city, :address_one, :address_state, :address_two, :address_zip, :name, :website
+  attributes :id, :name
 
 end

--- a/app/serializers/school_index_serializer.rb
+++ b/app/serializers/school_index_serializer.rb
@@ -1,5 +1,5 @@
 class SchoolIndexSerializer < SchoolBaseSerializer
 
-  attributes :contact_email, :contact_first_name, :contact_last_name, :contact_phone_number, :contact_title
+  attributes :website
 
 end

--- a/app/serializers/school_show_serializer.rb
+++ b/app/serializers/school_show_serializer.rb
@@ -1,3 +1,8 @@
 class SchoolShowSerializer < SchoolIndexSerializer
 
+  attributes :address_city, :address_one, :address_state,
+             :address_two, :address_zip, :contact_email,
+             :contact_first_name, :contact_last_name,
+             :contact_phone_number, :contact_title
+
 end

--- a/app/serializers/student_base_serializer.rb
+++ b/app/serializers/student_base_serializer.rb
@@ -1,5 +1,5 @@
 class StudentBaseSerializer < BaseSerializer
 
-  attributes :id, :cell_phone, :email, :first_name, :last_name
+  attributes :id, :first_name, :last_name
 
 end

--- a/app/serializers/student_group_serializer.rb
+++ b/app/serializers/student_group_serializer.rb
@@ -1,5 +1,8 @@
 class StudentGroupSerializer < StudentBaseSerializer
 
+  attributes :cell_phone, :email, :is_flagged,
+             :is_primary, :registration_status
+
   has_one :school, serializer: SchoolBaseSerializer
 
 end

--- a/app/serializers/student_index_serializer.rb
+++ b/app/serializers/student_index_serializer.rb
@@ -3,7 +3,7 @@ class StudentIndexSerializer < StudentBaseSerializer
   attributes :cell_phone, :email, :is_flagged,
              :is_primary, :registration_status
 
-  has_one :group, serializer: GroupStudentSerializer
+  has_one :group, serializer: GroupBaseSerializer
   has_one :school, serializer: SchoolBaseSerializer
 
 end

--- a/app/serializers/student_index_serializer.rb
+++ b/app/serializers/student_index_serializer.rb
@@ -1,6 +1,7 @@
 class StudentIndexSerializer < StudentBaseSerializer
 
-  attributes :is_flagged, :is_primary, :registration_status
+  attributes :cell_phone, :email, :is_flagged,
+             :is_primary, :registration_status
 
   has_one :group, serializer: GroupStudentSerializer
   has_one :school, serializer: SchoolBaseSerializer

--- a/app/serializers/student_show_serializer.rb
+++ b/app/serializers/student_show_serializer.rb
@@ -6,7 +6,7 @@ class StudentShowSerializer < StudentIndexSerializer
              :guardian_two_name, :guardian_two_phone, :guardian_two_email,
              :home_phone, :preferred_name, :shirt_size
 
-  has_many :comments, serializer: CommentIndexSerializer
+  has_many :comments, serializer: CommentBaseSerializer
 
   has_one :group, serializer: GroupStudentSerializer
   has_one :responsibility, serializer: ResponsibilityStudentSerializer

--- a/app/serializers/student_show_serializer.rb
+++ b/app/serializers/student_show_serializer.rb
@@ -8,7 +8,6 @@ class StudentShowSerializer < StudentIndexSerializer
 
   has_many :comments, serializer: CommentBaseSerializer
 
-  has_one :group, serializer: GroupStudentSerializer
   has_one :responsibility, serializer: ResponsibilityStudentSerializer
 
 end

--- a/app/serializers/user_base_serializer.rb
+++ b/app/serializers/user_base_serializer.rb
@@ -1,6 +1,6 @@
 class UserBaseSerializer < BaseSerializer
 
-  attributes :id, :email, :first_name, :has_sidebar, :is_admin, :last_name
+  attributes :id, :first_name, :last_name
 
   def visits
     object.visits.first(3)

--- a/app/serializers/user_show_serializer.rb
+++ b/app/serializers/user_show_serializer.rb
@@ -1,5 +1,7 @@
 class UserShowSerializer < UserIndexSerializer
 
+  attributes :email
+
   has_many :responsibilities, serializer: ResponsibilityIndexSerializer
 
 end


### PR DESCRIPTION
Fix #615 
Fix #719 

This pull optimizes our api controllers and serializers to date. We use `.includes` in our queries to include nested associations of instance we query, and we try our best to leave `attributes` and `relationships` in deeper levels of serialization when possible.
Note: in general, we'll use `base` serializers for `create` responses and for very basic relationships, so they should never have too many attributes in them!