### PR TITLE
Restructure form routes

### DIFF
--- a/app/assets/javascripts/constants/route_constants.es6.jsx
+++ b/app/assets/javascripts/constants/route_constants.es6.jsx
@@ -23,12 +23,8 @@
 
     get forms() {
       return {
-        school: (page, uuid) => {
-          return `/forms/school?page=${page}&uuid=${uuid}`;
-        },
-        student: (page, uuid) => {
-          return `/forms/student?page=${page}&uuid=${uuid}`;
-        },
+        school: (page, uuid) => `/forms/school/${uuid}?page=${page}`,
+        student: (page, uuid) => `/forms/student/${uuid}?page=${page}`,
       };
     }
 

--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -7,7 +7,7 @@ class FormsController < BaseController
     @target = params[:target]
     @uuid = params[:uuid]
     if @page > 1 && @uuid.nil?
-      redirect_to forms_path(page: 1, target: params[:target])
+      redirect_to forms_path(target: params[:target])
     end
   end
 

--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -11,4 +11,9 @@ class FormsController < BaseController
     end
   end
 
+  def success
+    @target = params[:target]
+    @uuid = params[:uuid]
+  end
+
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@
   get 'email', to: 'pages#email'
   get 'feedback', to: 'pages#feedback'
   get 'forms/:target', as: 'forms', to: 'forms#show'
+  get 'forms/:target/:uuid', to: 'forms#show'
   get 'login', to: 'pages#login'
   get 'profile', to: 'users#profile'
   get 'signup', to: 'pages#signup'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@
   get 'feedback', to: 'pages#feedback'
   get 'forms/:target', as: 'forms', to: 'forms#show'
   get 'forms/:target/:uuid', to: 'forms#show'
+  get 'forms/:target/:uuid/success', to: 'forms#success'
   get 'login', to: 'pages#login'
   get 'profile', to: 'users#profile'
   get 'signup', to: 'pages#signup'


### PR DESCRIPTION
Fix #1160 

Form routes are now:
`http://localhost:3000/forms/student/7cd37756-c54d-46f5-a96b-e517a47304c8?page=1`

Form success route:
`http://localhost:3000/forms/student/7cd37756-c54d-46f5-a96b-e517a47304c8/success`